### PR TITLE
arch-amdgpu: add Vega decode support for MFMA XF32 VOP3P ops

### DIFF
--- a/src/arch/amdgpu/vega/gpu_decoder.cc
+++ b/src/arch/amdgpu/vega/gpu_decoder.cc
@@ -3648,8 +3648,8 @@ IsaDecodeMethod Decoder::tableSubDecode_OP_VOP3P[] = {
     &Decoder::decode_invalid,
     &Decoder::decode_invalid,
     &Decoder::decode_invalid,
-    &Decoder::decode_invalid,
-    &Decoder::decode_invalid,
+    &Decoder::decode_OP_VOP3P__V_MFMA_F32_16X16X8_XF32,
+    &Decoder::decode_OP_VOP3P__V_MFMA_F32_32X32X4_XF32,
     &Decoder::decode_OP_VOP3P__V_MFMA_F32_32X32X1_2B_F32,
     &Decoder::decode_OP_VOP3P__V_MFMA_F32_16X16X1_4B_F32,
     &Decoder::decode_OP_VOP3P__V_MFMA_F32_4X4X1_16B_F32,
@@ -13752,6 +13752,18 @@ GPUStaticInst *
 Decoder::decode_OP_VOP3P__V_MFMA_F32_16X16X4_F32(MachInst iFmt)
 {
     return new Inst_VOP3P_MAI__V_MFMA_F32_16X16X4_F32(&iFmt->iFmt_VOP3P_MAI);
+}
+
+GPUStaticInst *
+Decoder::decode_OP_VOP3P__V_MFMA_F32_16X16X8_XF32(MachInst iFmt)
+{
+    return new Inst_VOP3P_MAI__V_MFMA_F32_16X16X8_XF32(&iFmt->iFmt_VOP3P_MAI);
+}
+
+GPUStaticInst *
+Decoder::decode_OP_VOP3P__V_MFMA_F32_32X32X4_XF32(MachInst iFmt)
+{
+    return new Inst_VOP3P_MAI__V_MFMA_F32_32X32X4_XF32(&iFmt->iFmt_VOP3P_MAI);
 }
 
 GPUStaticInst *

--- a/src/arch/amdgpu/vega/gpu_decoder.hh
+++ b/src/arch/amdgpu/vega/gpu_decoder.hh
@@ -1709,6 +1709,8 @@ class Decoder
     GPUStaticInst *decode_OP_VOP3P__V_MFMA_F32_4X4X1_16B_F32(MachInst);
     GPUStaticInst *decode_OP_VOP3P__V_MFMA_F32_32X32X2_F32(MachInst);
     GPUStaticInst *decode_OP_VOP3P__V_MFMA_F32_16X16X4_F32(MachInst);
+    GPUStaticInst *decode_OP_VOP3P__V_MFMA_F32_16X16X8_XF32(MachInst);
+    GPUStaticInst *decode_OP_VOP3P__V_MFMA_F32_32X32X4_XF32(MachInst);
     GPUStaticInst *decode_OP_VOP3P__V_MFMA_F32_32X32X4_2B_F16(MachInst);
     GPUStaticInst *decode_OP_VOP3P__V_MFMA_F32_16X16X4_4B_F16(MachInst);
     GPUStaticInst *decode_OP_VOP3P__V_MFMA_F32_4X4X4_16B_F16(MachInst);

--- a/src/arch/amdgpu/vega/insts/instructions.hh
+++ b/src/arch/amdgpu/vega/insts/instructions.hh
@@ -56381,6 +56381,18 @@ using Inst_VOP3P_MAI__V_MFMA_F32_16X16X1_4B_F32 =
     Inst_VOP3P_MAI__V_MFMA<1, 16, 16, 1, 4, ConstVecOperandF32, VecOperandF32,
                            &MNEM__V_MFMA_F32_16X16X1_4B_F32>;
 
+static const char *MNEM__V_MFMA_F32_16X16X8_XF32 =
+    "v_mfma_f32_16x16x8_xf32";
+using Inst_VOP3P_MAI__V_MFMA_F32_16X16X8_XF32 =
+    Inst_VOP3P_MAI__V_MFMA<1, 16, 16, 8, 1, ConstVecOperandF32, VecOperandF32,
+                           &MNEM__V_MFMA_F32_16X16X8_XF32>;
+
+static const char *MNEM__V_MFMA_F32_32X32X4_XF32 =
+    "v_mfma_f32_32x32x4_xf32";
+using Inst_VOP3P_MAI__V_MFMA_F32_32X32X4_XF32 =
+    Inst_VOP3P_MAI__V_MFMA<1, 32, 32, 4, 1, ConstVecOperandF32, VecOperandF32,
+                           &MNEM__V_MFMA_F32_32X32X4_XF32>;
+
 static const char *MNEM__V_MFMA_F64_4X4X4_4B_F64 = "v_mfma_f64_4x4x4_4b_f64";
 using Inst_VOP3P_MAI__V_MFMA_F64_4X4X4_4B_F64 =
     Inst_VOP3P_MAI__V_MFMA<2, 4, 4, 4, 4, ConstVecOperandF64, VecOperandF64,


### PR DESCRIPTION
Added decode paths for v_mfma_f32_16x16x8_xf32 and v_mfma_f32_32x32x4_xf32 (common in XLA) via updating table entries and adding instruction mnemonics.